### PR TITLE
Add Nested MetaTypeSerializer and Update URL Patterns for MetaType Importer API

### DIFF
--- a/netbox_metatype_importer/api/nested_serializers.py
+++ b/netbox_metatype_importer/api/nested_serializers.py
@@ -1,14 +1,14 @@
 from rest_framework import serializers
 
-from netbox.api.serializers import NetBoxModelSerializer
+from netbox.api.serializers import WritableNestedSerializer
 from ..models import MetaType
 
 __all__ = [
-    'MetaTypeSerializer',
+    'NestedMetaTypeSerializer',
 ]
 
 
-class MetaTypeSerializer(NetBoxModelSerializer):
+class NestedMetaTypeSerializer(WritableNestedSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name='plugins-api:netbox_metatype_importer-api:metatype-detail'
     )

--- a/netbox_metatype_importer/api/nested_serializers.py
+++ b/netbox_metatype_importer/api/nested_serializers.py
@@ -9,10 +9,12 @@ __all__ = [
 
 
 class NestedMetaTypeSerializer(WritableNestedSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_metatype_importer-api:metatype-detail'
+    url = serializers.HyperlinkedRelatedField(
+        view_name='metatype-detail',
+        lookup_field='name',
+        read_only=True
     )
 
     class Meta:
         model = MetaType
-        fields = '__all__'
+        fields = ('display', 'id', 'name', 'url')

--- a/netbox_metatype_importer/api/serializers.py
+++ b/netbox_metatype_importer/api/serializers.py
@@ -9,8 +9,10 @@ __all__ = [
 
 
 class MetaTypeSerializer(NetBoxModelSerializer):
-    url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_metatype_importer-api:metatype-detail'
+    url = serializers.HyperlinkedRelatedField(
+        view_name='metatype-detail',
+        lookup_field='name',
+        read_only=True
     )
 
     class Meta:

--- a/netbox_metatype_importer/api/urls.py
+++ b/netbox_metatype_importer/api/urls.py
@@ -1,10 +1,10 @@
-"""
-from rest_framework import routers
-from .views import MyModel1ViewSet
+from netbox.api.routers import NetBoxRouter
+from . import views
 
+app_name = 'netbox_metatype_importer'
 
-router = routers.DefaultRouter()
-router.register('', MyModel1ViewSet)
+router = NetBoxRouter()
+router.register('device-type', views.DeviceTypeViewSet, basename='device-type')
+router.register('module-type', views.ModuleTypeViewSet)
+
 urlpatterns = router.urls
-
-"""

--- a/netbox_metatype_importer/api/urls.py
+++ b/netbox_metatype_importer/api/urls.py
@@ -4,7 +4,9 @@ from . import views
 app_name = 'netbox_metatype_importer'
 
 router = NetBoxRouter()
+router.APIRootView = views.MetaTypeImporterAPIRootView
+
 router.register('device-type', views.DeviceTypeViewSet, basename='device-type')
-router.register('module-type', views.ModuleTypeViewSet)
+router.register('module-type', views.ModuleTypeViewSet, basename='module-type')
 
 urlpatterns = router.urls

--- a/netbox_metatype_importer/api/views.py
+++ b/netbox_metatype_importer/api/views.py
@@ -1,10 +1,28 @@
-"""
-from rest_framework.viewsets import ModelViewSet
-from netbox_metatype_importer.models import MyModel1
-from .serializers import MyModel1Serializer
+from rest_framework.routers import APIRootView
+
+from netbox.api.viewsets import NetBoxModelViewSet
+from .serializers import MetaTypeSerializer
+from ..choices import TypeChoices
+from ..filters import MetaTypeFilterSet
+from ..models import MetaType
 
 
-class MyModel1ViewSet(ModelViewSet):
-    queryset = MyModel1.objects.all()
-    serializer_class = MyModel1Serializer
-"""
+class MetaTypeImporterAPIRootView(APIRootView):
+    """
+    Meta Type Importer API Root
+    """
+
+    def get_view_name(self):
+        return 'Meta Type Importer API'
+
+
+class DeviceTypeViewSet(NetBoxModelViewSet):
+    queryset = MetaType.objects.filter(type=TypeChoices.TYPE_DEVICE)
+    serializer_class = MetaTypeSerializer
+    filterset_class = MetaTypeFilterSet
+
+
+class ModuleTypeViewSet(NetBoxModelViewSet):
+    queryset = MetaType.objects.filter(type=TypeChoices.TYPE_MODULE)
+    serializer_class = MetaTypeSerializer
+    filterset_class = MetaTypeFilterSet

--- a/netbox_metatype_importer/urls.py
+++ b/netbox_metatype_importer/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 
 from . import views
 
+app_name = 'netbox_metatype_importer'
+
 urlpatterns = [
     # Device types
     path('meta-device-types/', views.MetaDeviceTypeListView.as_view(), name='metadevicetype_list'),

--- a/netbox_metatype_importer/urls.py
+++ b/netbox_metatype_importer/urls.py
@@ -1,4 +1,5 @@
-from django.urls import path
+from django.urls import path, include
+from utilities.urls import get_model_urls
 
 from . import views
 
@@ -9,8 +10,10 @@ urlpatterns = [
     path('meta-device-types/', views.MetaDeviceTypeListView.as_view(), name='metadevicetype_list'),
     path('meta-device-types/load/', views.MetaDeviceTypeLoadView.as_view(), name='metadevicetype_load'),
     path('meta-device-types/import/', views.MetaDeviceTypeImportView.as_view(), name='metadevicetype_import'),
+    path('meta-device-types/<int:pk>/', include(get_model_urls(app_name, 'metadevicetype'))),
     # Module types
     path('meta-module-types/', views.MetaModuleTypeListView.as_view(), name='metamoduletype_list'),
     path('meta-module-types/load/', views.MetaModuleTypeLoadView.as_view(), name='metamoduletype_load'),
-    path('meta-module-types/import/', views.MetaModuleTypeImportView.as_view(), name='metamoduletype_import')
+    path('meta-module-types/import/', views.MetaModuleTypeImportView.as_view(), name='metamoduletype_import'),
+    path('meta-module-types/<int:pk>/', include(get_model_urls(app_name, 'metamoduletype'))),
 ]


### PR DESCRIPTION
This PR adds a Nested MetaTypeSerializer class to the netbox_metatype_importer/api/nested_serializers.py file, a MetaTypeSerializer with a HyperlinkedIdentityField view for the MetaType model, updates the URL patterns for the MetaType Importer API, adds an API root view and two viewsets filtered by type for the MetaType Importer API, and adds model URLs for the MetaTypeDeviceType and MetaModuleType models with an app_name variable to the urls.py file for better organization.