### PR TITLE
ci: adopt runner profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ permissions:
 jobs:
   test:
     name: Run Tests
-    uses: Onemind-Services-LLC/actions/.github/workflows/netbox-plugin-tests.yml@8ba8dea9401b08db920340ab52a47a0b3dd6e8d2
+    uses: Onemind-Services-LLC/actions/.github/workflows/netbox-plugin-tests.yml@d44af503e3f1bd61435617830a7c604c047dc408
     with:
+      lint-runs-on: ci-small
+      runs-on: ci-test
       plugin-name: 'netbox_metatype_importer'
       netbox-version: v4.6.1
       coverage-minimum: 45

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,7 @@ jobs:
       contents: read
       actions: read
       security-events: write
-    uses: Onemind-Services-LLC/actions/.github/workflows/codeql-analysis.yml@8ba8dea9401b08db920340ab52a47a0b3dd6e8d2
+    uses: Onemind-Services-LLC/actions/.github/workflows/codeql-analysis.yml@d44af503e3f1bd61435617830a7c604c047dc408
     with:
+      runs-on: ci-build
       languages: ${{ matrix.language }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ permissions:
 
 jobs:
   publish:
-    uses: Onemind-Services-LLC/actions/.github/workflows/python-publish.yml@8ba8dea9401b08db920340ab52a47a0b3dd6e8d2
+    uses: Onemind-Services-LLC/actions/.github/workflows/python-publish.yml@d44af503e3f1bd61435617830a7c604c047dc408
+    with:
+      runs-on: ci-test
     secrets:
       pypi-token: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Route jobs to the installed ARC profiles according to their tooling and resource needs. All profiles have zero idle runners, and the legacy runner remains available during migration. Shared workflow calls use actions/master commit `d44af503e3f1bd61435617830a7c604c047dc408`.

- `.github/workflows/ci.yml` / `test`: `ci-test`.
- `.github/workflows/codeql-analysis.yml` / `codeql`: `ci-build`.
- `.github/workflows/release.yml` / `publish`: `ci-test`.

### Target branch

Only the repository default branch, `master`. Workflow triggers, application code, secrets, and test settings are preserved. Empty retired workflows are deleted.

### Validation

YAML parsing and structural comparison confirm only runner routing, shared workflow references, and requested retired jobs change. No remaining job depends on a removed job. NetBox Documents and Zeus Organizations passed their canary PR workflows on the new profiles before this rollout.

### Jira Issue

No Jira issue supplied.

### Checklist

- [x] Reviewed job requirements and retained Docker support where required.
- [x] Shared routing support merged in actions/master before this change.
- [x] No credentials committed.
- [x] Default branch only; unrelated files preserved.
